### PR TITLE
Add a way to proxy upstream requests instead of external links

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -205,7 +205,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
         return new RestTemplate(new SimpleClientHttpRequestFactory() {
             @Override
             protected void prepareConnection(HttpURLConnection connection, String httpMethod ) {
-                connection.setInstanceFollowRedirects(false);
+                connection.setInstanceFollowRedirects(proxy != null);
             }
         });
     }


### PR DESCRIPTION
Fixes https://github.com/eclipse/openvsx/issues/452
Follows redirects on HEAD and GET requests

### Testing steps

- Add to dev/application.properties:
```
ovsx:
  upstream:
    proxy:
      enabled: true
    url: https://open-vsx.org/
```
- Run the server
- Test the upstream endpoints
- Expected result: all redirects provided by open-vsx.org are followed
```
$ curl -I http://localhost:8080/api/GitLab/gitlab-workflow/3.56.0/file/GitLab.gitlab-workflow-3.56.0.vsix
HTTP/1.1 200 
X-Rate-Limit-Remaining: 14
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
Last-Modified: Tue, 08 Nov 2022 13:34:56 GMT
ETag: "0x8DAC18E0676CF5A"
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: e7bd86f7-d01e-0043-2365-fea2ad000000
x-ms-version: 2009-09-19
x-ms-lease-status: unlocked
x-ms-blob-type: BlockBlob
Access-Control-Allow-Origin: *
Date: Tue, 22 Nov 2022 11:30:46 GMT
Content-Disposition: inline;filename=f.txt
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/octet-stream
Content-Length: 1389598

```
Signed-off-by: Kevin-mit-C <c.vl@gmx.com>